### PR TITLE
Add support for should.not on dynamics

### DIFF
--- a/src/buddy/Should.hx
+++ b/src/buddy/Should.hx
@@ -32,12 +32,15 @@ typedef SpecAssertion = Bool -> String -> Void;
 /**
  * This must be the first class in this package, since it overrides all other assertions otherwise.
  */
-class ShouldDynamic
+class ShouldDynamic extends Should<Dynamic>
 {
 	static public function should<T>(d : T, assert : SpecAssertion)
 	{
-		return new Should<T>(d, assert);
+		return new ShouldDynamic(d, assert);
 	}
+
+	public var not(get, never) : ShouldDynamic;
+	private function get_not() { return new ShouldDynamic(value, assert, !inverse); }
 }
 
 class ShouldInt extends Should<Int>

--- a/src/buddy/tests/AllTests.hx
+++ b/src/buddy/tests/AllTests.hx
@@ -10,6 +10,8 @@ class AllTests implements Buddy {}
 
 class EmptyTestClass { public function new() {} }
 
+enum Color { Red; Green; Blue; }
+
 class TestBasicFeatures extends BuddySuite
 {
 	private var testAfter : String;
@@ -39,6 +41,20 @@ class TestBasicFeatures extends BuddySuite
 
 			after({
 				testAfter = "after executed";
+			});
+		});
+
+		describe("Testing dynamics", {
+			var obj1 = { id: 1 };
+			var obj2 = { id: 2 };
+			var color1 = Red;
+			var color2 = Green;
+
+			it("should compare objects with be()", {
+				obj1.should.be(obj1);
+				obj1.should.not.be(obj2);
+				Red.should.be( Red );
+				Red.should.not.be( Green );
 			});
 		});
 


### PR DESCRIPTION
Previously it only worked if your object happened to match one of the other Should types (String, Iterable, Float etc).
