### PR TITLE
before outside of describe spec

### DIFF
--- a/src/buddy/tests/AllTests.hx
+++ b/src/buddy/tests/AllTests.hx
@@ -464,3 +464,24 @@ class BeforeAfterDescribe2 extends BuddySuite
 		});
 	}
 }
+
+class BeforeAfterDescribe3 extends BuddySuite
+{
+	public function new()
+	{
+
+		describe('outer describe', function () {
+			var a = 0;
+			before({
+				a = 1;
+			});
+
+			describe('inner describe', function () {
+				it('should run the before function before this spec', function () {
+					a.should.be(1);
+				});
+			});
+		});
+	}
+}
+


### PR DESCRIPTION
Hi !
I had no time last week to code so I couldn't test #11. 
I still have the same issue, here is a spec which reproduces my use case. You fixed part of it but the trick is that the 'before' is inside a nested 'describe'.

I'm not sure if this is a best practice but I sometimes do this with mocha.

Thanks !
