### PR TITLE
Use Sys.exit on sys platforms

### DIFF
--- a/src/buddy/GenerateMain.hx
+++ b/src/buddy/GenerateMain.hx
@@ -159,7 +159,7 @@ class GenerateMain
 				runner.run().then(function(_) { untyped __js__("if(process.platform == 'win32') { process.once('exit', function() { process.exit(runner.statusCode()); }); } else { process.exit(runner.statusCode()); }"); } );
 			};
 		}
-		else if(Context.defined("php") || Context.defined("java"))
+		else if(Context.defined("sys"))
 		{
 			body = macro {
 				runner.run().then(function(_) { Sys.exit(runner.statusCode()); });


### PR DESCRIPTION
This is a simple fix to allow Python (and any other future sys platform) to set the exit status correctly. I saw that there is some specific code for C#, Neko and C++ - but I'm not sure why (as `Sys.sleep` and `Sys.exit` should be available on all these platforms), so kindly take a look to see if this is the expected change!
Thanks!
