### PR TITLE
Split the progress per file

### DIFF
--- a/src/buddy/BuddySuite.hx
+++ b/src/buddy/BuddySuite.hx
@@ -1,6 +1,7 @@
 package buddy ;
 import buddy.reporting.Reporter;
 import haxe.CallStack;
+import haxe.macro.Expr;
 import haxe.PosInfos;
 import haxe.ds.GenericStack;
 import haxe.rtti.Meta;
@@ -84,10 +85,12 @@ class Spec
 	@:allow(buddy.SuitesRunner) public var status(default, null) : SpecStatus = Unknown;
 	@:allow(buddy.SuitesRunner) public var failures(default, null) = new Array<Failure>();
 	@:allow(buddy.SuitesRunner) public var traces(default, null) = new Array<String>();
+	@:allow(buddy.SuitesRunner) public var fileName(default, null) : String = "";
 
-	public function new(description : String) {
+	public function new(description : String, fileName : String) {
 		if(description == null) throw "Spec must have a description.";
 		this.description = description;
+		this.fileName = fileName;
 	}
 }
 
@@ -114,7 +117,7 @@ enum TestFunc {
 
 enum TestSpec {
 	Describe(suite : TestSuite, included : Bool);
-	It(description : String, test : Null<TestFunc>, included : Bool);
+	It(description : String, test : Null<TestFunc>, included : Bool, pos : PosInfos);
 }
 
 class TestSuite
@@ -229,9 +232,9 @@ class BuddySuite
 	 * @param	spec A block or function of tests, or leave out for pending
 	 * @param	hasInclude Used internally only
 	 */
-	private function it(desc : String, ?spec : TestFunc, _hasInclude = false) : Void {
+	private function it(desc : String, ?spec : TestFunc, _hasInclude = false, ?pos:PosInfos) : Void {
 		if (currentSuite == suite) throw "Cannot use 'it' outside of a describe block.";
-		currentSuite.specs.add(TestSpec.It(desc, spec, _hasInclude));
+		currentSuite.specs.add(TestSpec.It(desc, spec, _hasInclude, pos));
 	}
 
 	/**
@@ -240,9 +243,9 @@ class BuddySuite
 	 * @param	spec A block or function of tests, or leave out
 	 * @param	hasInclude Used internally only
 	 */
-	private function xit(desc : String, ?spec : TestFunc, _hasInclude = false) : Void {
+	private function xit(desc : String, ?spec : TestFunc, _hasInclude = false, ?pos:PosInfos) : Void {
 		if (currentSuite == suite) throw "Cannot use 'it' outside of a describe block.";
-		currentSuite.specs.add(TestSpec.It(desc, null, _hasInclude));
+		currentSuite.specs.add(TestSpec.It(desc, null, _hasInclude, pos));
 	}
 
 	/**

--- a/src/buddy/SuitesRunner.hx
+++ b/src/buddy/SuitesRunner.hx
@@ -205,7 +205,7 @@ class SuitesRunner
 					case Describe(suite, included):
 						if (included) return true;
 						else return traverse(suite);
-					case It(desc, _, included):
+					case It(desc, _, included, _):
 						return included;
 				}
 			});
@@ -347,10 +347,10 @@ class SuitesRunner
 				if (result != null) return { error: result.error, step: TSuite(result.suite) };
 				else return null;
 				
-			case It(desc, test, _):
+			case It(desc, test, _, pos):
 				// Assign top-level spec var here, so it can be used in reporting.
 				//trace("Starting it: " + desc);
-				var spec = buddy.tests.SelfTest.lastSpec = new Spec(desc);
+				var spec = buddy.tests.SelfTest.lastSpec = new Spec(desc, pos.fileName);
 				
 				var beforeEach = flatten(beforeEachStack);
 				var afterEach = flatten(afterEachStack);					

--- a/src/buddy/reporting/ConsoleFileReporter.hx
+++ b/src/buddy/reporting/ConsoleFileReporter.hx
@@ -20,9 +20,10 @@ import buddy.internal.sys.Flash;
 private typedef Sys = Flash;
 #end
 
-class ConsoleReporter extends TraceReporter
+class ConsoleFileReporter extends TraceReporter
 {
 	var progressString = "";
+	var lastFileName : String = null;
 	
 	public function new(colors = false) {
 		super(colors);
@@ -40,6 +41,18 @@ class ConsoleReporter extends TraceReporter
 
 	override public function progress(spec : Spec)
 	{
+		if(lastFileName != spec.fileName) {
+			if(lastFileName != null) {
+				progressString += "\n";
+				println("");
+			}
+
+			progressString += spec.fileName + ": ";
+			print(spec.fileName + ": ");
+
+			lastFileName = spec.fileName;
+		}
+
 		var status = switch(spec.status) {
 			case Failed: strCol(Red) + "X";
 			case Passed: strCol(Green) + ".";

--- a/src/buddy/reporting/ConsoleFileReporter.hx
+++ b/src/buddy/reporting/ConsoleFileReporter.hx
@@ -1,42 +1,13 @@
 package buddy.reporting;
 
-import buddy.BuddySuite;
-import buddy.reporting.Reporter;
-import haxe.CallStack;
-import buddy.reporting.TraceReporter.Color;
-using Lambda;
-using StringTools;
+import buddy.BuddySuite.Spec;
 
-#if nodejs
-import buddy.internal.sys.NodeJs;
-private typedef Sys = NodeJs;
-#elseif js
-import js.html.PreElement;
-import js.Browser;
-import buddy.internal.sys.Js;
-private typedef Sys = Js;
-#elseif flash
-import buddy.internal.sys.Flash;
-private typedef Sys = Flash;
-#end
-
-class ConsoleFileReporter extends TraceReporter
+class ConsoleFileReporter extends ConsoleReporter
 {
-	var progressString = "";
 	var lastFileName : String = null;
 	
 	public function new(colors = false) {
 		super(colors);
-	}
-
-	override public function start()
-	{
-		// A small convenience for PHP, to avoid creating a new reporter.
-		#if php
-		if (untyped __call__("php_sapi_name") != "cli") println("<pre>");
-		#end
-
-		return resolveImmediately(true);
 	}
 
 	override public function progress(spec : Spec)
@@ -64,36 +35,5 @@ class ConsoleFileReporter extends TraceReporter
 		print(status + strCol(Default));
 
 		return resolveImmediately(spec);
-	}
-
-	override public function done(suites : Iterable<Suite>, status : Bool)
-	{
-		#if (js && !nodejs && !travix)
-		Sys.println(progressString);
-		#end
-		
-		var output = super.done(suites, status);
-
-		#if php
-		if(untyped __call__("php_sapi_name") != "cli") println("</pre>");
-		#end	
-		
-		return output;
-	}
-
-	override private function print(s : String)
-	{
-		Sys.print(s);
-		#if php
-		untyped __call__("flush");
-		#end
-	}
-
-	override private function println(s : String)
-	{
-		Sys.println(s);
-		#if php
-		untyped __call__("flush");
-		#end
 	}
 }

--- a/src/buddy/reporting/ConsoleReporter.hx
+++ b/src/buddy/reporting/ConsoleReporter.hx
@@ -23,6 +23,7 @@ private typedef Sys = Flash;
 class ConsoleReporter extends TraceReporter
 {
 	var progressString = "";
+	var lastFileName : String = null;
 	
 	public function new(colors = false) {
 		super(colors);
@@ -40,6 +41,18 @@ class ConsoleReporter extends TraceReporter
 
 	override public function progress(spec : Spec)
 	{
+		if(lastFileName != spec.fileName) {
+			if(lastFileName != null) {
+				progressString += "\n";
+				println("");
+			}
+
+			progressString += spec.fileName + ": ";
+			print(spec.fileName + ": ");
+
+			lastFileName = spec.fileName;
+		}
+
 		var status = switch(spec.status) {
 			case Failed: strCol(Red) + "X";
 			case Passed: strCol(Green) + ".";


### PR DESCRIPTION
- Adds a `fileName` parameter to `Spec` such that the location of each `Spec` is carried along for eventual reporting.
- Modified the default `ConsoleReporter` to split the progress bar into chunks depending on the file name of where each `Spec` was defined (i.e., `it` calls), so that instead of:
  
  ```
  .....PPPPXX.....P..X....
  ```
  
  it looks like:
  
  ```
  Test1.hx: ....PP
  Test2.hx: PPXX....
  Test3.hx: .P..X....
  ```

Should more position information be included in `Spec` beyond just the fileName (a whole `PosInfos` perhaps?)

Closes #62 
