### PR TITLE
Haxe 4 compatibility (nodejs target)

### DIFF
--- a/src/buddy/internal/sys/NodeJs.hx
+++ b/src/buddy/internal/sys/NodeJs.hx
@@ -5,12 +5,16 @@ class NodeJs
 {
 	public static function print(s : String)
 	{
+		#if !macro
 		untyped __js__("process.stdout.write(s)");
+		#end
 	}
 
 	public static function println(s : String)
 	{
+		#if !macro
 		untyped __js__("console.log(s)");
+		#end
 	}
 }
 #end


### PR DESCRIPTION
I really like this lib, and hope it will still be around for a long time :)

At the moment, though, it is not fully compatible with Haxe 4.0.
I've only tested with nodejs, which works fine once this little fix is added:

`untyped __js__` breaks in `buddy.internal.sys.NodeJs.hx` with Haxe 4.0, due to a [breaking change](https://github.com/HaxeFoundation/haxe/wiki/Breaking-changes-in-Haxe-4.0.0#new-macro-interpreter).

This does not break anything for other targets or previous haxe versions.