### PR TITLE
Fix 

### DIFF
--- a/src/buddy/reporting/KarmaReporter.hx
+++ b/src/buddy/reporting/KarmaReporter.hx
@@ -1,3 +1,5 @@
+package buddy.reporting;
+
 import buddy.reporting.TraceReporter;
 import buddy.BuddySuite;
 import promhx.Promise;
@@ -23,7 +25,7 @@ typedef Karma = {
 	} -> Void,
 };
 
-class BuddyKarmaTestReporter extends TraceReporter {
+class KarmaReporter extends TraceReporter {
 	var karmaIsReady: Promise<Karma>;
 	var logs = [];
 	var specResults = [];


### PR DESCRIPTION
It turns out when I opened that PR that I didn't properly test it, and there were 2 very stupid mistakes in the code that ended up being merged:

- missing package declaration
- wrong class name (it was the name I used in testing)

I've fixed both of these. I wondered about doing an alias for the old (wrong) name with some `@:deprecated` metadata, but given that the class could never have compiled without the package definition, I think it's safe to rename it without calling it a breaking change.

Sorry for the mess around! I've actually tested it this time and it's working :)