### PR TITLE
fix compatibility with utest 1.7.1+

### DIFF
--- a/src/buddy/SuitesRunner.hx
+++ b/src/buddy/SuitesRunner.hx
@@ -440,6 +440,10 @@ class SuitesRunner
 							reportFailure(e, stack);
 						case TimeoutError(e, stack):
 							reportFailure(e, stack);
+						#if (utest >= "1.7.1")
+						case Ignore(reason):
+							spec.traces.push("Assertation ignored: " + reason);
+						#end
 					}
 				}
 				#end


### PR DESCRIPTION
utest 1.7.1 added an `Ignore(reason)` to `Assertation`, see https://github.com/fponticelli/utest/pull/43.