### PR TITLE
Add `-D buddy_suppress_unhandled_rejection`.

### DIFF
--- a/src/buddy/internal/GenerateMain.hx
+++ b/src/buddy/internal/GenerateMain.hx
@@ -250,10 +250,15 @@ class GenerateMain
 		else if(Context.defined("nodejs"))
 		{
 			body = macro {
-				untyped __js__("process.on('uncaughtException', function(err) {");
-				runner.haveUnrecoverableError(untyped err);
-				untyped __js__("})");
-				startRun(function() untyped __js__("process.exit(runner.statusCode())"));
+				untyped __js__("process.on('uncaughtException', {0})", function (err) {
+					runner.haveUnrecoverableError(err);
+				});
+				#if buddy_suppress_unhandled_rejection
+				untyped __js__("process.on('unhandledRejection', {0})", function (_) {});
+				#end
+				startRun(function () {
+					untyped __js__("process.exit({0})", runner.statusCode());
+				});
 			};
 		}
 		else if(Context.defined("sys"))


### PR DESCRIPTION
This is able to supperess the message of `unhandledRejection` on Node.js.
https://nodejs.org/docs/latest-v8.x/api/process.html#process_event_rejectionhandled

```haxe
class Main extends buddy.SingleSuite {
    public function new() {
        describe("test", {
            it("should pass", function (done) {
                js.Promise.reject("error");
                haxe.Timer.delay(done, 10);
            });
        });
    }
}
```

It pritnts the warning message if it doesn't use `-D buddy_suppress_unhandled_rejection`

```
(node:18748) UnhandledPromiseRejectionWarning: error
(node:18748) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This
 error originated either by throwing inside of an async function without a catch
 block, or by rejecting a promise which was not handled with .catch(). (rejectio
n id: 1)
(node:18748) [DEP0018] DeprecationWarning: Unhandled promise rejections are depr
ecated. In the future, promise rejections that are not handled will terminate th
e Node.js process with a non-zero exit code.
.
test
  should pass (Passed)
1 specs, 0 failures, 0 pending
```