### PR TITLE
Spec and suites now contain the time taken to run

### DIFF
--- a/src/buddy/BuddySuite.hx
+++ b/src/buddy/BuddySuite.hx
@@ -63,6 +63,16 @@ class Suite
 		}
 		return output;
 	}
+
+	public var time(get, never) : Float;
+	private function get_time() {
+		var total = 0.0;
+		for(step in steps) switch step {
+			case TSuite(s): total += s.time;
+			case TSpec(s): total += s.time;
+		}
+		return total;
+	}
 	
 	/**
 	 * Returns true if this suite and all below it passed.
@@ -86,6 +96,7 @@ class Spec
 	@:allow(buddy.SuitesRunner) public var failures(default, null) = new Array<Failure>();
 	@:allow(buddy.SuitesRunner) public var traces(default, null) = new Array<String>();
 	@:allow(buddy.SuitesRunner) public var fileName(default, null) : String = "";
+	@:allow(buddy.SuitesRunner) public var time(default, null) : Float = 0;
 
 	public function new(description : String, fileName : String) {
 		if(description == null) throw "Spec must have a description.";
@@ -117,7 +128,7 @@ enum TestFunc {
 
 enum TestSpec {
 	Describe(suite : TestSuite, included : Bool);
-	It(description : String, test : Null<TestFunc>, included : Bool, pos : PosInfos);
+	It(description : String, test : Null<TestFunc>, included : Bool, pos : PosInfos, time : Float);
 }
 
 class TestSuite
@@ -232,9 +243,9 @@ class BuddySuite
 	 * @param	spec A block or function of tests, or leave out for pending
 	 * @param	hasInclude Used internally only
 	 */
-	private function it(desc : String, ?spec : TestFunc, _hasInclude = false, ?pos:PosInfos) : Void {
+	private function it(desc : String, ?spec : TestFunc, _hasInclude = false, time:Float = 0, ?pos:PosInfos) : Void {
 		if (currentSuite == suite) throw "Cannot use 'it' outside of a describe block.";
-		currentSuite.specs.add(TestSpec.It(desc, spec, _hasInclude, pos));
+		currentSuite.specs.add(TestSpec.It(desc, spec, _hasInclude, pos, time));
 	}
 
 	/**
@@ -243,9 +254,9 @@ class BuddySuite
 	 * @param	spec A block or function of tests, or leave out
 	 * @param	hasInclude Used internally only
 	 */
-	private function xit(desc : String, ?spec : TestFunc, _hasInclude = false, ?pos:PosInfos) : Void {
+	private function xit(desc : String, ?spec : TestFunc, _hasInclude = false, time:Float = 0, ?pos:PosInfos) : Void {
 		if (currentSuite == suite) throw "Cannot use 'it' outside of a describe block.";
-		currentSuite.specs.add(TestSpec.It(desc, null, _hasInclude, pos));
+		currentSuite.specs.add(TestSpec.It(desc, null, _hasInclude, pos, time));
 	}
 
 	/**

--- a/src/buddy/BuddySuite.hx
+++ b/src/buddy/BuddySuite.hx
@@ -243,7 +243,7 @@ class BuddySuite
 	 * @param	spec A block or function of tests, or leave out for pending
 	 * @param	hasInclude Used internally only
 	 */
-	private function it(desc : String, ?spec : TestFunc, _hasInclude = false, time:Float = 0, ?pos:PosInfos) : Void {
+	private function it(desc : String, ?spec : TestFunc, _hasInclude = false, ?pos:PosInfos, time:Float = 0) : Void {
 		if (currentSuite == suite) throw "Cannot use 'it' outside of a describe block.";
 		currentSuite.specs.add(TestSpec.It(desc, spec, _hasInclude, pos, time));
 	}
@@ -254,7 +254,7 @@ class BuddySuite
 	 * @param	spec A block or function of tests, or leave out
 	 * @param	hasInclude Used internally only
 	 */
-	private function xit(desc : String, ?spec : TestFunc, _hasInclude = false, time:Float = 0, ?pos:PosInfos) : Void {
+	private function xit(desc : String, ?spec : TestFunc, _hasInclude = false, ?pos:PosInfos, time:Float = 0) : Void {
 		if (currentSuite == suite) throw "Cannot use 'it' outside of a describe block.";
 		currentSuite.specs.add(TestSpec.It(desc, null, _hasInclude, pos, time));
 	}

--- a/src/buddy/SuitesRunner.hx
+++ b/src/buddy/SuitesRunner.hx
@@ -354,7 +354,7 @@ class SuitesRunner
 				if (result != null) return { error: result.error, step: TSuite(result.suite) };
 				else return null;
 				
-			case It(desc, test, _, pos):
+			case It(desc, test, _, pos, time):
 				// Assign top-level spec var here, so it can be used in reporting.
 				//trace("Starting it: " + desc);
 				var spec = buddy.tests.SelfTest.lastSpec = new Spec(desc, pos.fileName);
@@ -474,10 +474,13 @@ class SuitesRunner
 				////////////////////////////////////////////////////////////////////////////
 				
 				var _syncResult : SyncTestResult = null;
+				var _startTime = haxe.Timer.stamp();
 				
 				function setSyncResult(status) {
 					if (!returnSync || _syncResult != null) return; 
 					_syncResult = status;
+
+					spec.time = haxe.Timer.stamp() - _startTime;
 				}
 				
 				// Set up fail and pending function


### PR DESCRIPTION
Hello,
I've recently started using a CI that allows reporting individual test times, so I've added time fields to suites and specs to reporters can output time taken. You can now get the time taken to run an individual spec or the time taken to run a suite and all its specs and sub suites.