### PR TITLE
Fix beforeAll() and afterAll() for haxe 4.0.0 rc 4

### DIFF
--- a/src/buddy/internal/SuiteBuilder.hx
+++ b/src/buddy/internal/SuiteBuilder.hx
@@ -208,7 +208,7 @@ class SuiteBuilder
 				e.expr = change.expr;
 				f.iter(injectAsync);
 
-			case macro beforeAll(function() $f), macro beforeAll($f):
+			case macro beforeAll(function() $f), macro beforeAll(() -> $f), macro beforeAll($f):
 				var change = macro beforeAll($sync(function() $f));
 				e.expr = change.expr;
 				f.iter(injectAsync);
@@ -218,7 +218,7 @@ class SuiteBuilder
 				e.expr = change.expr;
 				f.iter(injectAsync);
 
-			case macro afterAll(function() $f), macro afterAll($f):
+			case macro afterAll(function() $f), macro afterAll(() -> $f), macro afterAll($f):
 				var change = macro afterAll($sync(function() $f));
 				e.expr = change.expr;
 				f.iter(injectAsync);

--- a/src/buddy/internal/SuiteBuilder.hx
+++ b/src/buddy/internal/SuiteBuilder.hx
@@ -208,7 +208,11 @@ class SuiteBuilder
 				e.expr = change.expr;
 				f.iter(injectAsync);
 
+			#if (haxe_ver < 4)
+			case macro beforeAll(function() $f), macro beforeAll($f):
+			#else
 			case macro beforeAll(function() $f), macro beforeAll(() -> $f), macro beforeAll($f):
+			#end
 				var change = macro beforeAll($sync(function() $f));
 				e.expr = change.expr;
 				f.iter(injectAsync);
@@ -218,7 +222,11 @@ class SuiteBuilder
 				e.expr = change.expr;
 				f.iter(injectAsync);
 
+			#if (haxe_ver < 4)
+			case macro afterAll(function() $f), macro afterAll($f):
+			#else
 			case macro afterAll(function() $f), macro afterAll(() -> $f), macro afterAll($f):
+			#end
 				var change = macro afterAll($sync(function() $f));
 				e.expr = change.expr;
 				f.iter(injectAsync);


### PR DESCRIPTION
Using `beforeAll(() -> { /* ... */ })` on haxe 4.0.0 rc 4 gives the following error: `Unnamed lvalue functions are not supported`.