### PR TITLE
Replace __js__ with appropriate syntax

### DIFF
--- a/src/buddy/internal/GenerateMain.hx
+++ b/src/buddy/internal/GenerateMain.hx
@@ -265,10 +265,10 @@ class GenerateMain
 		else if(Context.defined("nodejs"))
 		{
 			body = macro {
-				untyped __js__("process.on('uncaughtException', function(err) {");
-				runner.haveUnrecoverableError(untyped err);
-				untyped __js__("})");
-				startRun(function() untyped __js__("process.exit(runner.statusCode())"));
+				js.Node.process.on('uncaughtException', function(err) {
+					runner.haveUnrecoverableError(err);
+				});
+				startRun(function() js.Node.process.exit(runner.statusCode()));
 			};
 		}
 		else if(Context.defined("sys"))

--- a/src/buddy/internal/sys/NodeJs.hx
+++ b/src/buddy/internal/sys/NodeJs.hx
@@ -6,14 +6,14 @@ class NodeJs
 	public static function print(s : String)
 	{
 		#if !macro
-		untyped __js__("process.stdout.write(s)");
+		js.Node.process.stdout.write(s);
 		#end
 	}
 
 	public static function println(s : String)
 	{
 		#if !macro
-		untyped __js__("console.log(s)");
+		js.Node.console.log(s);
 		#end
 	}
 }

--- a/src/buddy/tests/AllTests.hx
+++ b/src/buddy/tests/AllTests.hx
@@ -437,7 +437,7 @@ class TestBasicFeatures extends BuddySuite
 				#end
 				
 				#if js
-				var undef : Dynamic = untyped __js__("undefined");
+				var undef : Dynamic = js.Lib.undefined;
 				undef.should.be(null);
 				#end
 			});


### PR DESCRIPTION
Haxe 4.1 deprecates the usage of `untyped __js__` and print warnings.