### PR TITLE
Fix "should" with boxed basic types on static targets

### DIFF
--- a/src/buddy/Should.hx
+++ b/src/buddy/Should.hx
@@ -61,14 +61,14 @@ typedef SpecAssertion = Bool -> String -> Array<StackItem> -> Void;
 	}
 }
 
-@:keep class ShouldInt extends Should<Int>
+@:keep class ShouldInt extends Should<Null<Int>>
 {
-	static public function should(i : Int)
+	static public function should(i : Null<Int>)
 	{
 		return new ShouldInt(i);
 	}
 
-	public function new(value : Int, inverse = false)
+	public function new(value : Null<Int>, inverse = false)
 	{
 		super(value, inverse);
 	}
@@ -138,14 +138,14 @@ typedef SpecAssertion = Bool -> String -> Array<StackItem> -> Void;
 	}
 }
 
-@:keep class ShouldFloat extends Should<Float>
+@:keep class ShouldFloat extends Should<Null<Float>>
 {
-	static public function should(i : Float)
+	static public function should(i : Null<Float>)
 	{
 		return new ShouldFloat(i);
 	}
 
-	public function new(value : Float, inverse = false)
+	public function new(value : Null<Float>, inverse = false)
 	{
 		super(value, inverse);
 	}

--- a/src/buddy/tests/AllTests.hx
+++ b/src/buddy/tests/AllTests.hx
@@ -440,8 +440,14 @@ class TestBasicFeatures extends BuddySuite
 			it("should pass even if the var is null", {
 				var s : EmptyTestClass = null;
 				var d : Dynamic = null;
+				var i : Null<Int> = null;
+				var b : Null<Bool> = null;
+				var f : Null<Float> = null;
 				s.should.be(null);
 				d.should.be(null);
+				i.should.be(null);
+				b.should.be(null);
+				f.should.be(null);
 				
 				#if (js || neko || php || python || lua || interp)
 				var i : Int = null;


### PR DESCRIPTION
I added tests for Int, Bool, and Float, even though only Float seemed to have troubles compiling, for some reason.