### PR TITLE
Changes Std.is to Std.isOfType to fix Haxe 4 warnings.

### DIFF
--- a/src/buddy/Should.hx
+++ b/src/buddy/Should.hx
@@ -432,7 +432,7 @@ typedef SpecAssertion = Bool -> String -> Array<StackItem> -> Void;
 			#if java
 			// Handles exceptions that sneaks into the runtime,
 			// like exceptions thrown in the constructor.
-			if(Std.is(e, java.lang.Throwable)) {
+			if(Std.isOfType(e, java.lang.Throwable)) {
 				cause = cast(e, java.lang.Throwable).getCause();
 
 				if(cause != null && Type.getClassName(Type.getClass(cause)) == "haxe.lang.HaxeException")
@@ -464,7 +464,7 @@ typedef SpecAssertion = Bool -> String -> Array<StackItem> -> Void;
 			#if java
 			// Handles exceptions that sneaks into the runtime,
 			// like exceptions thrown in the constructor.
-			if(Std.is(e, java.lang.Throwable)) {
+			if(Std.isOfType(e, java.lang.Throwable)) {
 				cause = cast(e, java.lang.Throwable).getCause();
 
 				if(cause != null && Type.getClassName(Type.getClass(cause)) == "haxe.lang.HaxeException")
@@ -479,7 +479,7 @@ typedef SpecAssertion = Bool -> String -> Array<StackItem> -> Void;
 		var exceptionName = exception == null ? null : Type.getClassName(Type.getClass(exception));
 		if (exceptionName == null) exceptionName = "no exception";
 
-		var isCaught = Std.is(exception, type);
+		var isCaught = Std.isOfType(exception, type);
 		test(isCaught, p,
 			'Expected ${quote(value)} to throw type $typeName, $exceptionName was thrown instead',
 			'Expected ${quote(value)} not to throw type $typeName'
@@ -501,8 +501,8 @@ typedef SpecAssertion = Bool -> String -> Array<StackItem> -> Void;
 
 	private function quote(v : Dynamic)
 	{
-		if (Std.is(v, String)) return '"$v"';
-		if (Std.is(v, List)) return Std.string(Lambda.array(v));
+		if (Std.isOfType(v, String)) return '"$v"';
+		if (Std.isOfType(v, List)) return Std.string(Lambda.array(v));
 		return Std.string(v);
 	}
 
@@ -551,7 +551,7 @@ typedef SpecAssertion = Bool -> String -> Array<StackItem> -> Void;
 
 	public function beType(type : Dynamic, ?p : PosInfos)
 	{
-		test(Std.is(value, type), p,
+		test(Std.isOfType(value, type), p,
 			'Expected ${quote(value)} to be type ${quote(type)}',
 			'Expected ${quote(value)} not to be type ${quote(type)}'
 		);
@@ -559,8 +559,8 @@ typedef SpecAssertion = Bool -> String -> Array<StackItem> -> Void;
 
 	private function quote(v : Dynamic)
 	{
-		if (Std.is(v, String)) return '"$v"';
-		if (Std.is(v, List)) return Std.string(Lambda.array(v));
+		if (Std.isOfType(v, String)) return '"$v"';
+		if (Std.isOfType(v, List)) return Std.string(Lambda.array(v));
 		return Std.string(v);
 	}
 

--- a/src/buddy/tests/AllTests.hx
+++ b/src/buddy/tests/AllTests.hx
@@ -122,7 +122,7 @@ class TestBasicFeatures extends BuddySuite
 				color1.should.beType(Color);
 				color2.should.not.beType(Int); 
 				
-				Std.is([1, 2, 3], Array).should.be(true);
+				Std.isOfType([1, 2, 3], Array).should.be(true);
 				// Problem on C#:
 				//[1, 2, 3].should.beType(Array);
 			});


### PR DESCRIPTION
Std.is is deprecated and is causing warnings with Haxe 4.   This will break compatibility with Haxe 3, but if that's an issue I could add some conditional compilation to use Std.is with Haxe 3 and Std.isOfType for Haxe 4.  