### PR TITLE
Add beLessThanOrEqualTo, beGreaterThanOrEqualTo

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,11 @@ As you've seen in the examples, testing if specifications are correct is as simp
 
 `a.should.beLessThan(b)`
 
+`a.should.beLessThanOrEqualTo(b)`
+
 `a.should.beGreaterThan(b)`
+
+`a.should.beGreaterThanOrEqualTo(b)`
 
 ### Float
 

--- a/src/buddy/Should.hx
+++ b/src/buddy/Should.hx
@@ -151,11 +151,27 @@ typedef SpecAssertion = Bool -> String -> Array<StackItem> -> Void;
 		);
 	}
 
+	public function beLessThanOrEqualTo(expected : Int64, ?p : PosInfos)
+	{
+		test(value <= expected, p,
+			'Expected less than or equal to ${quote(expected)}, was ${quote(value)}',
+			'Expected not less than or equal to ${quote(expected)}, was ${quote(value)}'
+		);
+	}
+
 	public function beGreaterThan(expected : Int64, ?p : PosInfos)
 	{
 		test(value > expected, p,
 			'Expected greater than ${quote(expected)}, was ${quote(value)}',
 			'Expected not greater than ${quote(expected)}, was ${quote(value)}'
+		);
+	}
+
+	public function beGreaterThanOrEqualTo(expected : Int64, ?p : PosInfos)
+	{
+		test(value >= expected, p,
+			'Expected greater than or equal to ${quote(expected)}, was ${quote(value)}',
+			'Expected not greater than or equal to ${quote(expected)}, was ${quote(value)}'
 		);
 	}
 }
@@ -185,11 +201,27 @@ typedef SpecAssertion = Bool -> String -> Array<StackItem> -> Void;
 		);
 	}
 
+	public function beLessThanOrEqualTo(expected : Float, ?p : PosInfos)
+	{
+		test(value <= expected, p,
+			'Expected less than or equal to ${quote(expected)}, was ${quote(value)}',
+			'Expected not less than or equal to ${quote(expected)}, was ${quote(value)}'
+		);
+	}
+
 	public function beGreaterThan(expected : Float, ?p : PosInfos)
 	{
 		test(value > expected, p,
 			'Expected greater than ${quote(expected)}, was ${quote(value)}',
 			'Expected not greater than ${quote(expected)}, was ${quote(value)}'
+		);
+	}
+
+	public function beGreaterThanOrEqualTo(expected : Float, ?p : PosInfos)
+	{
+		test(value >= expected, p,
+			'Expected greater than or equal to ${quote(expected)}, was ${quote(value)}',
+			'Expected not greater than or equal to ${quote(expected)}, was ${quote(value)}'
 		);
 	}
 

--- a/src/buddy/Should.hx
+++ b/src/buddy/Should.hx
@@ -92,11 +92,27 @@ typedef SpecAssertion = Bool -> String -> Array<StackItem> -> Void;
 		);
 	}
 
+	public function beLessThanOrEqualTo(expected : Int, ?p : PosInfos)
+	{
+		test(value <= expected, p,
+			'Expected less than or equal to ${quote(expected)}, was ${quote(value)}',
+			'Expected not less than or equal to ${quote(expected)}, was ${quote(value)}'
+		);
+	}
+
 	public function beGreaterThan(expected : Int, ?p : PosInfos)
 	{
 		test(value > expected, p,
 			'Expected greater than ${quote(expected)}, was ${quote(value)}',
 			'Expected not greater than ${quote(expected)}, was ${quote(value)}'
+		);
+	}
+
+	public function beGreaterThanOrEqualTo(expected : Int, ?p : PosInfos)
+	{
+		test(value >= expected, p,
+			'Expected greater than or equal to ${quote(expected)}, was ${quote(value)}',
+			'Expected not greater than or equal to ${quote(expected)}, was ${quote(value)}'
 		);
 	}
 }

--- a/src/buddy/tests/AllTests.hx
+++ b/src/buddy/tests/AllTests.hx
@@ -220,11 +220,11 @@ class TestBasicFeatures extends BuddySuite
 				int.should.beLessThan(3.1);
 			});
 
-			it("should have a beMoreThan() method", {
+			it("should have a beGreaterThan() method", {
 				int.should.beGreaterThan(2);
 			});
 
-			it("beMoreThan should compare against float", {
+			it("beGreaterThan should compare against float", {
 				int.should.beGreaterThan(2.9);
 			});
 		});

--- a/src/buddy/tests/AllTests.hx
+++ b/src/buddy/tests/AllTests.hx
@@ -222,10 +222,12 @@ class TestBasicFeatures extends BuddySuite
 
 			it("should have a beLessThanOrEqualTo() method", {
 				int.should.beLessThanOrEqualTo(4);
+				int.should.beLessThanOrEqualTo(int);
 			});
 
 			it("beLessThanOrEqualTo should compare against float", {
 				int.should.beLessThanOrEqualTo(3.1);
+				int.should.beLessThanOrEqualTo(int);
 			});
 
 			it("should have a beGreaterThan() method", {
@@ -238,10 +240,12 @@ class TestBasicFeatures extends BuddySuite
 
 			it("should have a beGreaterThanOrEqualTo() method", {
 				int.should.beGreaterThanOrEqualTo(2);
+				int.should.beGreaterThanOrEqualTo(int);
 			});
 
 			it("beGreaterThanOrEqualTo should compare against float", {
 				int.should.beGreaterThanOrEqualTo(2.9);
+				int.should.beGreaterThanOrEqualTo(int);
 			});
 		});
 
@@ -254,6 +258,7 @@ class TestBasicFeatures extends BuddySuite
 
 			it("should have a beLessThanOrEqualTo() method", {
 				int64.should.beLessThanOrEqualTo(Int64.make(2, 0));
+				int64.should.beLessThanOrEqualTo(int64);
 			});
 
 			it("should have a beGreaterThan() method", {
@@ -262,6 +267,7 @@ class TestBasicFeatures extends BuddySuite
 
 			it("should have a beGreaterThanOrEqualTo() method", {
 				int64.should.beGreaterThanOrEqualTo(2147483647);
+				int64.should.beGreaterThanOrEqualTo(int64);
 			});
 			
 			it("should test 'be' with equality, not identity", {
@@ -286,10 +292,12 @@ class TestBasicFeatures extends BuddySuite
 
 			it("should have a beLessThanOrEqualTo() method", {
 				number.should.beLessThanOrEqualTo(4.23);
+				number.should.beLessThanOrEqualTo(number);
 			});
 
 			it("beLessThanOrEqualTo should compare against int", {
 				number.should.beLessThanOrEqualTo(cast(4, Int));
+				number.should.beLessThanOrEqualTo(number);
 			});
 
 			it("should have a beGreaterThan() method", {
@@ -302,10 +310,12 @@ class TestBasicFeatures extends BuddySuite
 
 			it("should have a beGreaterThanOrEqualTo() method", {
 				number.should.beGreaterThanOrEqualTo(2.9);
+				number.should.beGreaterThanOrEqualTo(number);
 			});
 
 			it("beGreaterThanOrEqualTo should compare against int", {
 				number.should.beGreaterThanOrEqualTo(cast(2, Int));
+				number.should.beGreaterThanOrEqualTo(number);
 			});
 
 			it("should have a beCloseTo() method", {

--- a/src/buddy/tests/AllTests.hx
+++ b/src/buddy/tests/AllTests.hx
@@ -236,7 +236,7 @@ class TestBasicFeatures extends BuddySuite
 				int64.should.beLessThan(Int64.make(2, 0));
 			});
 
-			it("should have a beMoreThan() method", {
+			it("should have a beGreaterThan() method", {
 				int64.should.beGreaterThan(2147483647);
 			});
 			
@@ -260,11 +260,11 @@ class TestBasicFeatures extends BuddySuite
 				number.should.beLessThan(cast(4, Int));
 			});
 
-			it("should have a beMoreThan() method", {
+			it("should have a beGreaterThan() method", {
 				number.should.beGreaterThan(2.9);
 			});
 
-			it("beMoreThan should compare against int", {
+			it("beGreaterThan should compare against int", {
 				number.should.beGreaterThan(cast(2, Int));
 			});
 

--- a/src/buddy/tests/AllTests.hx
+++ b/src/buddy/tests/AllTests.hx
@@ -220,12 +220,28 @@ class TestBasicFeatures extends BuddySuite
 				int.should.beLessThan(3.1);
 			});
 
+			it("should have a beLessThanOrEqualTo() method", {
+				int.should.beLessThanOrEqualTo(4);
+			});
+
+			it("beLessThanOrEqualTo should compare against float", {
+				int.should.beLessThanOrEqualTo(3.1);
+			});
+
 			it("should have a beGreaterThan() method", {
 				int.should.beGreaterThan(2);
 			});
 
 			it("beGreaterThan should compare against float", {
 				int.should.beGreaterThan(2.9);
+			});
+
+			it("should have a beGreaterThanOrEqualTo() method", {
+				int.should.beGreaterThanOrEqualTo(2);
+			});
+
+			it("beGreaterThanOrEqualTo should compare against float", {
+				int.should.beGreaterThanOrEqualTo(2.9);
 			});
 		});
 
@@ -236,8 +252,16 @@ class TestBasicFeatures extends BuddySuite
 				int64.should.beLessThan(Int64.make(2, 0));
 			});
 
+			it("should have a beLessThanOrEqualTo() method", {
+				int64.should.beLessThanOrEqualTo(Int64.make(2, 0));
+			});
+
 			it("should have a beGreaterThan() method", {
 				int64.should.beGreaterThan(2147483647);
+			});
+
+			it("should have a beGreaterThanOrEqualTo() method", {
+				int64.should.beGreaterThanOrEqualTo(2147483647);
 			});
 			
 			it("should test 'be' with equality, not identity", {
@@ -260,12 +284,28 @@ class TestBasicFeatures extends BuddySuite
 				number.should.beLessThan(cast(4, Int));
 			});
 
+			it("should have a beLessThanOrEqualTo() method", {
+				number.should.beLessThanOrEqualTo(4.23);
+			});
+
+			it("beLessThanOrEqualTo should compare against int", {
+				number.should.beLessThanOrEqualTo(cast(4, Int));
+			});
+
 			it("should have a beGreaterThan() method", {
 				number.should.beGreaterThan(2.9);
 			});
 
 			it("beGreaterThan should compare against int", {
 				number.should.beGreaterThan(cast(2, Int));
+			});
+
+			it("should have a beGreaterThanOrEqualTo() method", {
+				number.should.beGreaterThanOrEqualTo(2.9);
+			});
+
+			it("beGreaterThanOrEqualTo should compare against int", {
+				number.should.beGreaterThanOrEqualTo(cast(2, Int));
 			});
 
 			it("should have a beCloseTo() method", {


### PR DESCRIPTION
As the title says, this PR adds these two methods to numeric types, to allow testing for `x <= y` and `x >= y` succinctly. 

Thanks for the great library!